### PR TITLE
司法書士に関する源泉徴収計算ロジック追加

### DIFF
--- a/lib/hoshu/calculator/calculator.ts
+++ b/lib/hoshu/calculator/calculator.ts
@@ -2,8 +2,9 @@ import tedori from './tedori';
 import shihoushoshi from './shihoushoshi';
 import genkouKouen from './genkou-kouen';
 
+
 export default {
-  genkouKouen,
   tedori,
-  shihoushoshi
+  shihoushoshi,
+  genkouKouen
 }

--- a/lib/hoshu/calculator/calculator.ts
+++ b/lib/hoshu/calculator/calculator.ts
@@ -1,7 +1,9 @@
 import tedori from './tedori';
+import shihoushoshi from './shihoushoshi';
 import genkouKouen from './genkou-kouen';
 
 export default {
+  genkouKouen,
   tedori,
-  genkouKouen
+  shihoushoshi
 }

--- a/lib/hoshu/calculator/shihoushoshi.ts
+++ b/lib/hoshu/calculator/shihoushoshi.ts
@@ -1,7 +1,7 @@
 import BN  from 'bignumber.js'
 
 export default function (originKingaku: number) : GensenReponse {
-  let kingaku : BN = new BN(originKingaku);
+  let kingaku = new BN(originKingaku);
   let gensen = kingaku.minus(10000).times(0.1021).floor().toNumber();
 
   if (gensen < 0) {

--- a/lib/hoshu/calculator/shihoushoshi.ts
+++ b/lib/hoshu/calculator/shihoushoshi.ts
@@ -1,6 +1,11 @@
-export default function (kingaku: number) : GensenReponse {
+import BN, {BigNumber} from 'bignumber.js'
+
+export default function (originKingaku: number) : GensenReponse {
+  let kingaku = new BigNumber(originKingaku);
+  let gensen = kingaku.minus(10000).times(0.1021).floor().toNumber();
+
   return {
-    gensen: 100,
-    shiharai: 2000
+    gensen: gensen,
+    shiharai: originKingaku
   };
 }

--- a/lib/hoshu/calculator/shihoushoshi.ts
+++ b/lib/hoshu/calculator/shihoushoshi.ts
@@ -4,6 +4,10 @@ export default function (originKingaku: number) : GensenReponse {
   let kingaku = new BigNumber(originKingaku);
   let gensen = kingaku.minus(10000).times(0.1021).floor().toNumber();
 
+  if (gensen < 0) {
+    gensen = 0
+  }
+
   return {
     gensen: gensen,
     shiharai: originKingaku

--- a/lib/hoshu/calculator/shihoushoshi.ts
+++ b/lib/hoshu/calculator/shihoushoshi.ts
@@ -1,0 +1,6 @@
+export default function (kingaku: number) : GensenReponse {
+  return {
+    gensen: 100,
+    shiharai: 2000
+  };
+}

--- a/lib/hoshu/calculator/shihoushoshi.ts
+++ b/lib/hoshu/calculator/shihoushoshi.ts
@@ -1,7 +1,7 @@
-import BN, {BigNumber} from 'bignumber.js'
+import BN  from 'bignumber.js'
 
 export default function (originKingaku: number) : GensenReponse {
-  let kingaku = new BigNumber(originKingaku);
+  let kingaku : BN = new BN(originKingaku);
   let gensen = kingaku.minus(10000).times(0.1021).floor().toNumber();
 
   if (gensen < 0) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "types": "types/type.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "tsc -p tsconfig.test.json && ava build/**/**/*.test.js"
+    "test": "tsc -p tsconfig.test.json && ava"
   },
   "devDependencies": {
     "ava": "^0.22.0",
@@ -17,5 +17,11 @@
   },
   "dependencies": {
     "bignumber.js": "^4.1.0"
+  },
+  "ava": {
+    "files": [
+      "build/**/*.test.js"
+    ],
+    "verbose": true
   }
 }

--- a/test/hoshu/calculator/shihoushoshi.test.ts
+++ b/test/hoshu/calculator/shihoushoshi.test.ts
@@ -1,35 +1,25 @@
 import test from 'ava';
-import gensen from '../../../lib/hoshu/calculator/shihoushoshi';
+import gensen from '../../../lib/index';
 
 // No.2801 司法書士等に支払う報酬・料金
 // https://www.nta.go.jp/taxanswer/gensen/2801.htm
 
 test('国税局のサンプル例', (t) => {
-  const r:GensenReponse = gensen(50000);
-  t.is(r.gensen, 4084);
-  t.is(r.shiharai, 50000);
+  t.deepEqual(gensen.hoshu.shihoushoshi(50000), { gensen: 4084, shiharai: 50000 });
 });
 
 test('1万円を引いた時にマイナスであれば源泉徴収は0とする', (t) => {
-  const r:GensenReponse = gensen(9999);
-  t.is(r.gensen, 0);
-  t.is(r.shiharai, 9999);
+  t.deepEqual(gensen.hoshu.shihoushoshi(9999), { gensen: 0, shiharai: 9999 });
 });
 
 test('1万円ちょうどの場合', (t) => {
-  const r:GensenReponse = gensen(10000);
-  t.is(r.gensen, 0);
-  t.is(r.shiharai, 10000);
+  t.deepEqual(gensen.hoshu.shihoushoshi(10000), { gensen: 0, shiharai: 10000 });
 });
 
 test('小数点以下切り捨て', (t) => {
-  const r:GensenReponse = gensen(50001);
-  t.is(r.gensen, 4084);
-  t.is(r.shiharai, 50001);
+  t.deepEqual(gensen.hoshu.shihoushoshi(50001), { gensen: 4084, shiharai: 50001 });
 });
 
 test('100万円を超える場合も、10.21%で計算される', (t) => {
-  const r:GensenReponse = gensen(1000001);
-  t.is(r.gensen, 101079);
-  t.is(r.shiharai, 1000001);
+  t.deepEqual(gensen.hoshu.shihoushoshi(1000001), { gensen: 101079, shiharai: 1000001 });
 });

--- a/test/hoshu/calculator/shihoushoshi.test.ts
+++ b/test/hoshu/calculator/shihoushoshi.test.ts
@@ -10,3 +10,20 @@ test('国税局のサンプル例', (t) => {
   t.is(r.shiharai, 50000);
 });
 
+test('1万円を引いた時にマイナスであれば源泉徴収は0とする', (t) => {
+  const r:GensenReponse = gensen(9999);
+  t.is(r.gensen, 0);
+  t.is(r.shiharai, 9999);
+});
+
+test('1万円ちょうどの場合', (t) => {
+  const r:GensenReponse = gensen(10000);
+  t.is(r.gensen, 0);
+  t.is(r.shiharai, 10000);
+});
+
+test('小数点以下切り捨て', (t) => {
+  const r:GensenReponse = gensen(50001);
+  t.is(r.gensen, 4084);
+  t.is(r.shiharai, 50001);
+});

--- a/test/hoshu/calculator/shihoushoshi.test.ts
+++ b/test/hoshu/calculator/shihoushoshi.test.ts
@@ -27,3 +27,9 @@ test('小数点以下切り捨て', (t) => {
   t.is(r.gensen, 4084);
   t.is(r.shiharai, 50001);
 });
+
+test('100万円を超える場合も、10.21%で計算される', (t) => {
+  const r:GensenReponse = gensen(1000001);
+  t.is(r.gensen, 101079);
+  t.is(r.shiharai, 1000001);
+});

--- a/test/hoshu/calculator/shihoushoshi.test.ts
+++ b/test/hoshu/calculator/shihoushoshi.test.ts
@@ -1,0 +1,12 @@
+import test from 'ava';
+import gensen from '../../../lib/hoshu/calculator/shihoushoshi';
+
+// No.2801 司法書士等に支払う報酬・料金
+// https://www.nta.go.jp/taxanswer/gensen/2801.htm
+
+test('国税局のサンプル例', (t) => {
+  const r:GensenReponse = gensen(50000);
+  t.is(r.gensen, 4084);
+  t.is(r.shiharai, 50000);
+});
+


### PR DESCRIPTION
以下を参考にロジックを組んだ
https://www.nta.go.jp/taxanswer/gensen/2801.htm

司法書士は、金額を1万マイナスして10.21%かけるのが特徴