### PR TITLE
馬主の計算ロジックを追加

### DIFF
--- a/lib/hoshu/calculator/banushi.ts
+++ b/lib/hoshu/calculator/banushi.ts
@@ -1,0 +1,26 @@
+import BN from "bignumber.js";
+
+// P21 13 馬主に支払う競馬の賞金
+// http://www.nta.go.jp/shiraberu/ippanjoho/pamph/gensen/shikata2017/pdf/09.pdf
+// {支払金額 - (支払金額 * 20% + 60万)} * 10.21%
+
+const BANUSHI_KOUJO_BASE = new BN(600000);
+const BANUSHI_KOUJO_RATE = new BN(0.20);
+
+export default function(originZeikomi: number): Kingaku {
+  const zeikomi = new BN(originZeikomi);
+  const koujo = zeikomi.times(BANUSHI_KOUJO_RATE).add(BANUSHI_KOUJO_BASE);
+
+  let zei = zeikomi.minus(koujo);
+  if (zei.lessThan(0)) {
+    zei = new BN(0);
+  } else {
+    zei = zei.times(0.1021).floor();
+  }
+
+  return {
+    zei: zei.toNumber(),
+    zeikomi: zeikomi.toNumber(),
+    zeinuki: zeikomi.minus(zei).toNumber(),
+  };
+}

--- a/lib/hoshu/calculator/calculator.ts
+++ b/lib/hoshu/calculator/calculator.ts
@@ -1,3 +1,4 @@
+import banushi from "./banushi";
 import bengoshiZeirishi from "./bengoshi-zeirishi";
 import gaikouin from "./gaikouin";
 import genkouKouen from "./genkou-kouen";
@@ -8,6 +9,7 @@ import shihoushoshi from "./shihoushoshi";
 import tedori from "./tedori";
 
 export default {
+  banushi,
   bengoshiZeirishi,
   gaikouin,
   genkouKouen,

--- a/test/hoshu/calculator/banushi.test.ts
+++ b/test/hoshu/calculator/banushi.test.ts
@@ -1,0 +1,46 @@
+import test from "ava";
+import gensen from "../../../lib/index";
+
+// P21 13 馬主に支払う競馬の賞金
+// http://www.nta.go.jp/shiraberu/ippanjoho/pamph/gensen/shikata2017/pdf/09.pdf
+// {支払金額 - (支払金額 * 20% + 60万)} * 10.21%
+
+test("賞金100万の場合", (t) => {
+  t.deepEqual(
+    gensen.hoshu.banushi(1000000),
+    {
+      zei: 20420,
+      zeikomi: 1000000,
+      zeinuki: 979580,
+    });
+});
+
+test("賞金7500013円の場合（税金が1円になる下限）", (t) => {
+  t.deepEqual(
+    gensen.hoshu.banushi(750013),
+    {
+      zei: 1,
+      zeikomi: 750013,
+      zeinuki: 750012,
+    });
+});
+
+test("賞金75万円の場合（0になる境界値）", (t) => {
+  t.deepEqual(
+    gensen.hoshu.banushi(750000),
+    {
+      zei: 0,
+      zeikomi: 750000,
+      zeinuki: 750000,
+    });
+});
+
+test("賞金749999円（0になる境界値未満）", (t) => {
+  t.deepEqual(
+    gensen.hoshu.banushi(749999),
+    {
+      zei: 0,
+      zeikomi: 749999,
+      zeinuki: 749999,
+    });
+});


### PR DESCRIPTION
P21 13 馬主に支払う競馬の賞金
http://www.nta.go.jp/shiraberu/ippanjoho/pamph/gensen/shikata2017/pdf/09.pdf
{支払金額 - (支払金額 * 20% + 60万)} * 10.21%

展開して
{支払金額 * 0.80 - 60万} * 10.21% でもいいけど、今回は順当に計算組んだ 