### PR TITLE
国税庁HPリニューアルに伴いリンクを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 `gensen` は日本の源泉徴収税計算用のライブラリです。
 
 ## 説明
-[国税庁の資料](https://www.nta.go.jp/shiraberu/ippanjoho/pamph/gensen/shikata2017/01.htm)を元にした実装になっています。
+[国税庁の資料](https://www.nta.go.jp/publication/pamph/gensen/shikata2017/01.htm)を元にした実装になっています。
 
 ## 導入方法
 

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -68,7 +68,7 @@
 				<p><a href="https://gitter.im/jptax/gensen?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img src="https://badges.gitter.im/jptax/gensen.svg" alt="Join the chat at https://gitter.im/jptax/gensen"></a></p>
 				<p><code>gensen</code> は日本の源泉徴収税計算用のライブラリです。</p>
 				<h2 id="-">説明</h2>
-				<p><a href="https://www.nta.go.jp/shiraberu/ippanjoho/pamph/gensen/shikata2017/01.htm">国税庁の資料</a>を元にした実装になっています。</p>
+				<p><a href="https://www.nta.go.jp/publication/pamph/gensen/shikata2017/01.htm">国税庁の資料</a>を元にした実装になっています。</p>
 				<h2 id="-">導入方法</h2>
 				<h3 id="-">ブラウザ</h3>
 				<ul>

--- a/docs/api/modules/_houshu_calculator_banushi_.html
+++ b/docs/api/modules/_houshu_calculator_banushi_.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">BANUSHI_<wbr>KOUJO_<wbr>BASE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">BigNumber</span><span class="tsd-signature-symbol"> =&nbsp;new BN(600000)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/banushi.ts#L7">houshu/calculator/banushi.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/banushi.ts#L7">houshu/calculator/banushi.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -104,7 +104,7 @@
 					<div class="tsd-signature tsd-kind-icon">BANUSHI_<wbr>KOUJO_<wbr>RATE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">BigNumber</span><span class="tsd-signature-symbol"> =&nbsp;new BN(0.20)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/banushi.ts#L8">houshu/calculator/banushi.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/banushi.ts#L8">houshu/calculator/banushi.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/banushi.ts#L8">houshu/calculator/banushi.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/banushi.ts#L8">houshu/calculator/banushi.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/api/modules/_houshu_calculator_gaikouin_.html
+++ b/docs/api/modules/_houshu_calculator_gaikouin_.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">GAIKOUIN_<wbr>KYUYO_<wbr>KOUJO_<wbr>KINGAKU<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">120000</span><span class="tsd-signature-symbol"> =&nbsp;120000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/gaikouin.ts#L6">houshu/calculator/gaikouin.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/gaikouin.ts#L6">houshu/calculator/gaikouin.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/gaikouin.ts#L6">houshu/calculator/gaikouin.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/gaikouin.ts#L6">houshu/calculator/gaikouin.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/api/modules/_houshu_calculator_hostess_.html
+++ b/docs/api/modules/_houshu_calculator_hostess_.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">HOSTESS_<wbr>KOUJO_<wbr>OF_<wbr>DAY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> =&nbsp;5000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/hostess.ts#L3">houshu/calculator/hostess.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/hostess.ts#L3">houshu/calculator/hostess.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/hostess.ts#L18">houshu/calculator/hostess.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/hostess.ts#L18">houshu/calculator/hostess.ts:18</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -137,7 +137,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/hostess.ts#L3">houshu/calculator/hostess.ts:3</a></li>
+									<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/hostess.ts#L3">houshu/calculator/hostess.ts:3</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/api/modules/_houshu_calculator_koukoku_shoukin_.html
+++ b/docs/api/modules/_houshu_calculator_koukoku_shoukin_.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">KOUKOKU_<wbr>SHOUKIN_<wbr>KOUJO_<wbr>KINGAKU<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">500000</span><span class="tsd-signature-symbol"> =&nbsp;500000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/koukoku-shoukin.ts#L6">houshu/calculator/koukoku-shoukin.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/koukoku-shoukin.ts#L6">houshu/calculator/koukoku-shoukin.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/koukoku-shoukin.ts#L6">houshu/calculator/koukoku-shoukin.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/koukoku-shoukin.ts#L6">houshu/calculator/koukoku-shoukin.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/api/modules/_houshu_calculator_pro_boxer_.html
+++ b/docs/api/modules/_houshu_calculator_pro_boxer_.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">BOXER_<wbr>KOUJO_<wbr>KINGAKU<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">50000</span><span class="tsd-signature-symbol"> =&nbsp;50000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/pro-boxer.ts#L6">houshu/calculator/pro-boxer.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/pro-boxer.ts#L6">houshu/calculator/pro-boxer.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/pro-boxer.ts#L19">houshu/calculator/pro-boxer.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/pro-boxer.ts#L19">houshu/calculator/pro-boxer.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -134,7 +134,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/pro-boxer.ts#L6">houshu/calculator/pro-boxer.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/pro-boxer.ts#L6">houshu/calculator/pro-boxer.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/api/modules/_houshu_calculator_shihoushoshi_.html
+++ b/docs/api/modules/_houshu_calculator_shihoushoshi_.html
@@ -91,7 +91,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/shihoushoshi.ts#L1">houshu/calculator/shihoushoshi.ts:1</a></li>
+									<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/shihoushoshi.ts#L1">houshu/calculator/shihoushoshi.ts:1</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/api/modules/_houshu_calculator_shinryou_.html
+++ b/docs/api/modules/_houshu_calculator_shinryou_.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">SHINRYOU_<wbr>KOUJO<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> =&nbsp;200000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/shinryou.ts#L4">houshu/calculator/shinryou.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/shinryou.ts#L4">houshu/calculator/shinryou.ts:4</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -115,13 +115,13 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/shinryou.ts#L4">houshu/calculator/shinryou.ts:4</a></li>
+									<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/shinryou.ts#L4">houshu/calculator/shinryou.ts:4</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
 								<div class="lead">
 									<p>社会保険診療報酬支払基金が支払う診療報酬
-									<a href="http://www.nta.go.jp/shiraberu/ippanjoho/pamph/gensen/shikata2017/pdf/09.pdf">http://www.nta.go.jp/shiraberu/ippanjoho/pamph/gensen/shikata2017/pdf/09.pdf</a></p>
+									<a href="https://www.nta.go.jp/publication/pamph/gensen/shikata2017/pdf/09.pdf">https://www.nta.go.jp/publication/pamph/gensen/shikata2017/pdf/09.pdf</a></p>
 								</div>
 							</div>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/api/modules/_houshu_calculator_standard_.html
+++ b/docs/api/modules/_houshu_calculator_standard_.html
@@ -94,7 +94,7 @@
 					<div class="tsd-signature tsd-kind-icon">CHANGE_<wbr>CALCULATE_<wbr>LOGIC_<wbr>LINE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> =&nbsp;1000000</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/standard.ts#L3">houshu/calculator/standard.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/standard.ts#L3">houshu/calculator/standard.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/standard.ts#L16">houshu/calculator/standard.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/standard.ts#L16">houshu/calculator/standard.ts:16</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -134,7 +134,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/standard.ts#L3">houshu/calculator/standard.ts:3</a></li>
+									<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/standard.ts#L3">houshu/calculator/standard.ts:3</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/api/modules/_houshu_calculator_tedori_.html
+++ b/docs/api/modules/_houshu_calculator_tedori_.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">TEDORI_<wbr>NIDANKAI_<wbr>ZEIRITSU_<wbr>KINGAKU<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">897900</span><span class="tsd-signature-symbol"> =&nbsp;897900</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/tedori.ts#L4">houshu/calculator/tedori.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/tedori.ts#L4">houshu/calculator/tedori.ts:4</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -115,7 +115,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/calculator/tedori.ts#L4">houshu/calculator/tedori.ts:4</a></li>
+									<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/calculator/tedori.ts#L4">houshu/calculator/tedori.ts:4</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/api/modules/_houshu_houshu_.houshu.html
+++ b/docs/api/modules/_houshu_houshu_.houshu.html
@@ -78,7 +78,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/houshu.ts#L3">houshu/houshu.ts:3</a></li>
+								<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/houshu.ts#L3">houshu/houshu.ts:3</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">banushi<span class="tsd-signature-symbol">:</span> <a href="_houshu_calculator_banushi_.html#default" class="tsd-signature-type">default</a><span class="tsd-signature-symbol"> =&nbsp;calculator.banushi</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/houshu.ts#L9">houshu/houshu.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/houshu.ts#L9">houshu/houshu.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">gaikouin<span class="tsd-signature-symbol">:</span> <a href="_houshu_calculator_gaikouin_.html#default" class="tsd-signature-type">default</a><span class="tsd-signature-symbol"> =&nbsp;calculator.gaikouin</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/houshu.ts#L10">houshu/houshu.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/houshu.ts#L10">houshu/houshu.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">hostess<span class="tsd-signature-symbol">:</span> <a href="_houshu_calculator_hostess_.html#default" class="tsd-signature-type">default</a><span class="tsd-signature-symbol"> =&nbsp;calculator.hostess</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/houshu.ts#L11">houshu/houshu.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/houshu.ts#L11">houshu/houshu.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -150,7 +150,7 @@
 					<div class="tsd-signature tsd-kind-icon">koukoku<wbr>Shoukin<span class="tsd-signature-symbol">:</span> <a href="_houshu_calculator_koukoku_shoukin_.html#default" class="tsd-signature-type">default</a><span class="tsd-signature-symbol"> =&nbsp;calculator.koukokuShoukin</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/houshu.ts#L12">houshu/houshu.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/houshu.ts#L12">houshu/houshu.ts:12</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -160,7 +160,7 @@
 					<div class="tsd-signature tsd-kind-icon">pro<wbr>Boxer<span class="tsd-signature-symbol">:</span> <a href="_houshu_calculator_pro_boxer_.html#default" class="tsd-signature-type">default</a><span class="tsd-signature-symbol"> =&nbsp;calculator.proBoxer</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/houshu.ts#L13">houshu/houshu.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/houshu.ts#L13">houshu/houshu.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -170,7 +170,7 @@
 					<div class="tsd-signature tsd-kind-icon">shihoushoshi<span class="tsd-signature-symbol">:</span> <a href="_houshu_calculator_shihoushoshi_.html#default" class="tsd-signature-type">default</a><span class="tsd-signature-symbol"> =&nbsp;calculator.shihoushoshi</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/houshu.ts#L14">houshu/houshu.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/houshu.ts#L14">houshu/houshu.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -180,7 +180,7 @@
 					<div class="tsd-signature tsd-kind-icon">shinryou<span class="tsd-signature-symbol">:</span> <a href="_houshu_calculator_shinryou_.html#default" class="tsd-signature-type">default</a><span class="tsd-signature-symbol"> =&nbsp;calculator.shinryou</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/houshu.ts#L15">houshu/houshu.ts:15</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/houshu.ts#L15">houshu/houshu.ts:15</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -190,7 +190,7 @@
 					<div class="tsd-signature tsd-kind-icon">standard<span class="tsd-signature-symbol">:</span> <a href="_houshu_calculator_standard_.html#default" class="tsd-signature-type">default</a><span class="tsd-signature-symbol"> =&nbsp;calculator.standard</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/houshu.ts#L16">houshu/houshu.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/houshu.ts#L16">houshu/houshu.ts:16</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -200,7 +200,7 @@
 					<div class="tsd-signature tsd-kind-icon">tedori<span class="tsd-signature-symbol">:</span> <a href="_houshu_calculator_tedori_.html#default" class="tsd-signature-type">default</a><span class="tsd-signature-symbol"> =&nbsp;calculator.tedori</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jptax/gensen/blob/04df2e1/lib/houshu/houshu.ts#L17">houshu/houshu.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/jptax/gensen/blob/82f0de7/lib/houshu/houshu.ts#L17">houshu/houshu.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/lib/houshu/calculator/banushi.ts
+++ b/lib/houshu/calculator/banushi.ts
@@ -1,7 +1,7 @@
 import BN from "bignumber.js";
 
 // P21 13 馬主に支払う競馬の賞金
-// http://www.nta.go.jp/shiraberu/ippanjoho/pamph/gensen/shikata2017/pdf/09.pdf
+// https://www.nta.go.jp/publication/pamph/gensen/shikata2017/pdf/09.pdf
 // {支払金額 - (支払金額 * 20% + 60万)} * 10.21%
 
 const BANUSHI_KOUJO_BASE = new BN(600000);

--- a/lib/houshu/calculator/pro-boxer.ts
+++ b/lib/houshu/calculator/pro-boxer.ts
@@ -1,7 +1,7 @@
 import BN from "bignumber.js";
 
 // プロボクサーの業務に関する報酬・料金
-// http://www.nta.go.jp/shiraberu/ippanjoho/pamph/gensen/shikata2017/pdf/09.pdf
+// https://www.nta.go.jp/publication/pamph/gensen/shikata2017/pdf/09.pdf
 
 const BOXER_KOUJO_KINGAKU = 50000;
 

--- a/lib/houshu/calculator/shinryou.ts
+++ b/lib/houshu/calculator/shinryou.ts
@@ -5,7 +5,7 @@ const SHINRYOU_KOUJO: number = 200000;
 
 /**
  * 社会保険診療報酬支払基金が支払う診療報酬
- * http://www.nta.go.jp/shiraberu/ippanjoho/pamph/gensen/shikata2017/pdf/09.pdf
+ * https://www.nta.go.jp/publication/pamph/gensen/shikata2017/pdf/09.pdf
  * @param originZeikomi 支払金額
  */
 export default function(originZeikomi: number): Kingaku {

--- a/test/houshu/calculator/banushi.test.ts
+++ b/test/houshu/calculator/banushi.test.ts
@@ -2,7 +2,7 @@ import test from "ava";
 import gensen from "../../../lib/index";
 
 // P21 13 馬主に支払う競馬の賞金
-// http://www.nta.go.jp/shiraberu/ippanjoho/pamph/gensen/shikata2017/pdf/09.pdf
+// https://www.nta.go.jp/publication/pamph/gensen/shikata2017/pdf/09.pdf
 // {支払金額 - (支払金額 * 20% + 60万)} * 10.21%
 
 test("賞金100万の場合", (t) => {

--- a/test/houshu/calculator/pro-boxer.test.ts
+++ b/test/houshu/calculator/pro-boxer.test.ts
@@ -2,7 +2,7 @@ import test from "ava";
 import proBoxer from "../../../lib/houshu/calculator/pro-boxer";
 
 // プロボクサーの業務に関する報酬・料金
-// http://www.nta.go.jp/shiraberu/ippanjoho/pamph/gensen/shikata2017/pdf/09.pdf
+// https://www.nta.go.jp/publication/pamph/gensen/shikata2017/pdf/09.pdf
 
 test("50,000以下の場合", (t) => {
   t.deepEqual(proBoxer(30000), { zei: 0, zeinuki: 30000, zeikomi: 30000 });

--- a/test/houshu/calculator/shinryou.test.ts
+++ b/test/houshu/calculator/shinryou.test.ts
@@ -2,7 +2,7 @@ import test from "ava";
 import gensen from "../../../lib/index";
 
 // 社会保険診療報酬支払基金が支払う診療報酬
-// http://www.nta.go.jp/shiraberu/ippanjoho/pamph/gensen/shikata2017/pdf/09.pdf
+// https://www.nta.go.jp/publication/pamph/gensen/shikata2017/pdf/09.pdf
 
 test("20万円を引いた時にマイナスであれば源泉徴収は0とする", (t) => {
   t.deepEqual(


### PR DESCRIPTION
国税庁HPリニューアルに伴い、
READMEやソースコードのコメント記述のリンクが不正となっていたので、
新しいURLに変更しました。

fix #36